### PR TITLE
IColumnType.Name is made internal.

### DIFF
--- a/src/Pure.RelationalSchema.Abstractions/ColumnType/IColumnType.cs
+++ b/src/Pure.RelationalSchema.Abstractions/ColumnType/IColumnType.cs
@@ -4,5 +4,5 @@ namespace Pure.RelationalSchema.Abstractions.ColumnType;
 
 public interface IColumnType
 {
-    IString Name { get; }
+    internal IString Name { get; }
 }


### PR DESCRIPTION
Closes #8 